### PR TITLE
Feat/DT-2225: Update postgres to v16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   postgres:
-    image: postgres:10.4
+    image: postgres:16.4
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
As part of the DBT PAAS migration we need to know that the app works okay using Postgres >=14. This PR just bumps our local version to 16 and works without any issues.