### PR TITLE
Chore/Build style dependencies to avoid setuptools errors when deploying

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,16 +30,18 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "autopep8"
-version = "1.4.4"
+version = "2.3.1"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
-    {file = "autopep8-1.4.4.tar.gz", hash = "sha256:4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"},
+    {file = "autopep8-2.3.1-py2.py3-none-any.whl", hash = "sha256:a203fe0fcad7939987422140ab17a930f684763bf7335bdb6709991dd7ef6c2d"},
+    {file = "autopep8-2.3.1.tar.gz", hash = "sha256:8d6c87eba648fdcfc83e29b788910b8643171c395d9c4bcf115ece035b9c9dda"},
 ]
 
 [package.dependencies]
-pycodestyle = ">=2.4.0"
+pycodestyle = ">=2.12.0"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "beautifulsoup4"
@@ -857,19 +859,19 @@ files = [
 
 [[package]]
 name = "flake8"
-version = "6.1.0"
+version = "7.1.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 optional = false
 python-versions = ">=3.8.1"
 files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
+    {file = "flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"},
+    {file = "flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38"},
 ]
 
 [package.dependencies]
 mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
+pycodestyle = ">=2.12.0,<2.13.0"
+pyflakes = ">=3.2.0,<3.3.0"
 
 [[package]]
 name = "freezegun"
@@ -1463,13 +1465,13 @@ files = [
 
 [[package]]
 name = "pycodestyle"
-version = "2.11.1"
+version = "2.12.1"
 description = "Python style guide checker"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
+    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
+    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
 ]
 
 [[package]]
@@ -1485,13 +1487,13 @@ files = [
 
 [[package]]
 name = "pyflakes"
-version = "3.1.0"
+version = "3.2.0"
 description = "passive checker of Python programs"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
 ]
 
 [[package]]
@@ -2181,4 +2183,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "997c617fadd32089480e05e9783d3d97a20560c29efaa69bf9a7f8f1c5245037"
+content-hash = "f784726cfb7910faf7e4dc96469afac2707c41b424832656bc00f925a1e75b62"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-autopep8 = "1.4.4"
+autopep8 = "2.3.1"
 beautifulsoup4 = "4.8.2"
 boto3 = "^1.17.92"
 botocore = "^1.20.92"
@@ -79,6 +79,7 @@ webencodings = "0.5.1"
 whitenoise = "^5.2.0"
 xlsxwriter = "1.2.8"
 gevent = "^23.9.0"
+flake8 = "7.1.1"
 
 
 
@@ -86,7 +87,7 @@ gevent = "^23.9.0"
 black = "^24.3.0"
 coverage = "^7.2.3"
 freezegun = "^1.2.2"
-flake8 = "^6.0.0"
+flake8 = "^7.1.1"
 
 [tool.poetry.group.production.dependencies]
 elastic-apm = "^6.15.1"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,86 +1,92 @@
-anyascii==0.3.2
-asgiref==3.7.2
-autopep8==1.4.4
-beautifulsoup4==4.8.2
-black==24.3.0
-boto3==1.17.112
-botocore==1.20.112
-certifi==2024.7.4
-chardet==3.0.4
-charset-normalizer==3.3.2
-click==8.1.7
-coverage==7.3.2
-defusedxml==0.7.1
-dj-database-url==0.5.0
-Django==4.2.15
-django-appconf==1.0.6
-django-compressor==4.4
-django-environ==0.4.5
-django-filter==23.5
-django-ipware==3.0.7
-django-log-formatter-asim==0.0.5
-django-log-formatter-ecs==0.0.5
-django-modelcluster==6.3
-django-oauth-toolkit==1.2.0
-django-permissionedforms==0.1
-django-sass-processor==1.3
-django-simple-history==3.4.0
-django-staff-sso-client==4.2.1
-django-storages==1.11.1
-django-taggit==5.0.1
-django-treebeard==4.7
-djangorestframework==3.14.0
-docutils==0.14
-draftjs-exporter==2.1.6
-et-xmlfile==1.1.0
-filetype==1.2.0
-flake8==6.1.0
-freezegun==1.2.2
-gevent==23.9.1
-greenlet==3.0.1
-html5lib==1.0.1
-idna==3.7
-jmespath==0.9.4
-kubi-ecs-logger==0.1.2
-l18n==2021.3
-laces==0.1.1
-libsass==0.22.0
-marshmallow==3.19.0
-mccabe==0.7.0
-mohawk==1.1.0
-mypy-extensions==1.0.0
-oauthlib==3.0.2
-openpyxl==3.1.2
-packaging==23.2
-pathspec==0.11.2
-Pillow==10.3.0
-pillow-heif==0.13.1
-platformdirs==3.11.0
-psycopg2==2.9.9
-pycodestyle==2.11.1
-pyflakes==3.1.0
-python-dateutil==2.8.0
-pytz==2024.1
-raven==6.10.0
-rcssmin==1.1.1
-requests==2.31.0
-requests-oauthlib==1.2.0
-rjsmin==1.2.1
-s3transfer==0.4.2
-sentry-sdk==2.8.0
-six==1.16.0
-soupsieve==2.0.1
-sqlparse==0.5.0
-telepath==0.3.1
-Unidecode==1.1.1
-urllib3==1.26.18
-wagtail==6.0.1
-wagtailcodeblock==1.29.0.1
-waitress==2.1.2
-Wand==0.5.5
-webencodings==0.5.1
-whitenoise==5.3.0
-Willow==1.6.2
-XlsxWriter==1.2.8
-zope.event==5.0
-zope.interface==6.1
+anyascii==0.3.2 ; python_version >= "3.9" and python_version < "4.0"
+asgiref==3.7.2 ; python_version >= "3.9" and python_version < "4.0"
+autopep8==2.3.1 ; python_version >= "3.9" and python_version < "4.0"
+beautifulsoup4==4.8.2 ; python_version >= "3.9" and python_version < "4.0"
+boto3==1.17.112 ; python_version >= "3.9" and python_version < "4.0"
+botocore==1.20.112 ; python_version >= "3.9" and python_version < "4.0"
+certifi==2023.7.22 ; python_version >= "3.9" and python_version < "4.0"
+cffi==1.16.0 ; platform_python_implementation == "CPython" and sys_platform == "win32" and python_version >= "3.9" and python_version < "4.0"
+cfgv==3.4.0 ; python_version >= "3.9" and python_version < "4"
+chardet==3.0.4 ; python_version >= "3.9" and python_version < "4.0"
+charset-normalizer==3.3.2 ; python_version >= "3.9" and python_version < "4.0"
+defusedxml==0.7.1 ; python_version >= "3.9" and python_version < "4.0"
+distlib==0.3.8 ; python_version >= "3.9" and python_version < "4"
+dj-database-url==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+django-appconf==1.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-compressor==4.4 ; python_version >= "3.9" and python_version < "4.0"
+django-environ==0.4.5 ; python_version >= "3.9" and python_version < "4.0"
+django-filter==23.3 ; python_version >= "3.9" and python_version < "4.0"
+django-ipware==3.0.7 ; python_version >= "3.9" and python_version < "4.0"
+django-log-formatter-asim==0.0.5 ; python_version >= "3.9" and python_version < "4"
+django-log-formatter-ecs==0.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-modelcluster==6.0 ; python_version >= "3.9" and python_version < "4.0"
+django-oauth-toolkit==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+django-permissionedforms==0.1 ; python_version >= "3.9" and python_version < "4.0"
+django-sass-processor==1.3 ; python_version >= "3.9" and python_version < "4.0"
+django-simple-history==3.4.0 ; python_version >= "3.9" and python_version < "4.0"
+django-staff-sso-client==3.1.1 ; python_version >= "3.9" and python_version < "4.0"
+django-storages==1.11.1 ; python_version >= "3.9" and python_version < "4.0"
+django-taggit==2.1.0 ; python_version >= "3.9" and python_version < "4.0"
+django-treebeard==4.7 ; python_version >= "3.9" and python_version < "4.0"
+django==3.2.25 ; python_version >= "3.9" and python_version < "4.0"
+djangorestframework==3.15.1 ; python_version >= "3.9" and python_version < "4.0"
+docutils==0.14 ; python_version >= "3.9" and python_version < "4.0"
+draftjs-exporter==2.1.6 ; python_version >= "3.9" and python_version < "4.0"
+et-xmlfile==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+filelock==3.15.4 ; python_version >= "3.9" and python_version < "4"
+filetype==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+flake8==7.1.1 ; python_version >= "3.9" and python_version < "4.0"
+gevent==23.9.1 ; python_version >= "3.9" and python_version < "4.0"
+greenlet==3.0.1 ; platform_python_implementation == "CPython" and python_version < "4.0" and python_version >= "3.9"
+html5lib==1.0.1 ; python_version >= "3.9" and python_version < "4.0"
+identify==2.6.0 ; python_version >= "3.9" and python_version < "4"
+idna==3.7 ; python_version >= "3.9" and python_version < "4.0"
+jmespath==0.9.4 ; python_version >= "3.9" and python_version < "4.0"
+kubi-ecs-logger==0.1.2 ; python_version >= "3.9" and python_version < "4"
+l18n==2021.3 ; python_version >= "3.9" and python_version < "4.0"
+libsass==0.22.0 ; python_version >= "3.9" and python_version < "4.0"
+marshmallow==3.19.0 ; python_version >= "3.9" and python_version < "4"
+mccabe==0.7.0 ; python_version >= "3.9" and python_version < "4.0"
+mohawk==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+nodeenv==1.9.1 ; python_version >= "3.9" and python_version < "4"
+oauthlib==3.0.2 ; python_version >= "3.9" and python_version < "4.0"
+openpyxl==3.1.2 ; python_version >= "3.9" and python_version < "4.0"
+packaging==23.2 ; python_version >= "3.9" and python_version < "4"
+pillow-heif==0.13.1 ; python_version >= "3.9" and python_version < "4.0"
+pillow==10.3.0 ; python_version >= "3.9" and python_version < "4.0"
+platformdirs==3.11.0 ; python_version >= "3.9" and python_version < "4"
+pre-commit==3.8.0 ; python_version >= "3.9" and python_version < "4"
+psycopg2==2.9.9 ; python_version >= "3.9" and python_version < "4.0"
+pycodestyle==2.12.1 ; python_version >= "3.9" and python_version < "4.0"
+pycparser==2.21 ; python_version >= "3.9" and platform_python_implementation == "CPython" and sys_platform == "win32" and python_version < "4.0"
+pyflakes==3.2.0 ; python_version >= "3.9" and python_version < "4.0"
+python-dateutil==2.8.0 ; python_version >= "3.9" and python_version < "4.0"
+pytz==2020.5 ; python_version >= "3.9" and python_version < "4.0"
+pyyaml==6.0.2 ; python_version >= "3.9" and python_version < "4"
+raven==6.10.0 ; python_version >= "3.9" and python_version < "4.0"
+rcssmin==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+requests-oauthlib==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+requests==2.32.0 ; python_version >= "3.9" and python_version < "4.0"
+rjsmin==1.2.1 ; python_version >= "3.9" and python_version < "4.0"
+s3transfer==0.4.2 ; python_version >= "3.9" and python_version < "4.0"
+sentry-sdk==1.14.0 ; python_version >= "3.9" and python_version < "4.0"
+setuptools==70.0.0 ; python_version >= "3.9" and python_version < "4.0"
+six==1.16.0 ; python_version >= "3.9" and python_version < "4.0"
+soupsieve==2.0.1 ; python_version >= "3.9" and python_version < "4.0"
+sqlparse==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+telepath==0.3.1 ; python_version >= "3.9" and python_version < "4.0"
+tomli==2.0.1 ; python_version >= "3.9" and python_version < "3.11"
+typing-extensions==4.8.0 ; python_version >= "3.9" and python_version < "3.11"
+unidecode==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+urllib3==1.26.18 ; python_version >= "3.9" and python_version < "4.0"
+virtualenv==20.26.3 ; python_version >= "3.9" and python_version < "4"
+wagtail==5.1.3 ; python_version >= "3.9" and python_version < "4.0"
+wagtailcodeblock==1.29.0.1 ; python_version >= "3.9" and python_version < "4.0"
+waitress==2.1.2 ; python_version >= "3.9" and python_version < "4.0"
+wand==0.5.5 ; python_version >= "3.9" and python_version < "4.0"
+webencodings==0.5.1 ; python_version >= "3.9" and python_version < "4.0"
+whitenoise==5.3.0 ; python_version >= "3.9" and python_version < "4"
+willow[heif]==1.6.2 ; python_version >= "3.9" and python_version < "4.0"
+xlsxwriter==1.2.8 ; python_version >= "3.9" and python_version < "4.0"
+zope-event==5.0 ; python_version >= "3.9" and python_version < "4.0"
+zope-interface==6.1 ; python_version >= "3.9" and python_version < "4.0"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,86 +1,99 @@
-anyascii==0.3.2
-asgiref==3.7.2
-autopep8==1.4.4
-beautifulsoup4==4.8.2
-black==24.3.0
-boto3==1.17.112
-botocore==1.20.112
-certifi==2024.7.4
-chardet==3.0.4
-charset-normalizer==3.3.2
-click==8.1.7
-coverage==7.3.2
-defusedxml==0.7.1
-dj-database-url==0.5.0
-Django==4.2.15
-django-appconf==1.0.6
-django-compressor==4.4
-django-environ==0.4.5
-django-filter==23.5
-django-ipware==3.0.7
-django-log-formatter-asim==0.0.5
-django-log-formatter-ecs==0.0.5
-django-modelcluster==6.3
-django-oauth-toolkit==1.2.0
-django-permissionedforms==0.1
-django-sass-processor==1.3
-django-simple-history==3.4.0
-django-staff-sso-client==4.2.1
-django-storages==1.11.1
-django-taggit==5.0.1
-django-treebeard==4.7
-djangorestframework==3.14.0
-docutils==0.14
-draftjs-exporter==2.1.6
-et-xmlfile==1.1.0
-filetype==1.2.0
-flake8==6.1.0
-freezegun==1.2.2
-gevent==23.9.1
-greenlet==3.0.1
-html5lib==1.0.1
-idna==3.7
-jmespath==0.9.4
-kubi-ecs-logger==0.1.2
-l18n==2021.3
-laces==0.1.1
-libsass==0.22.0
-marshmallow==3.19.0
-mccabe==0.7.0
-mohawk==1.1.0
-mypy-extensions==1.0.0
-oauthlib==3.0.2
-openpyxl==3.1.2
-packaging==23.2
-pathspec==0.11.2
-Pillow==10.3.0
-pillow-heif==0.13.1
-platformdirs==3.11.0
-psycopg2==2.9.9
-pycodestyle==2.11.1
-pyflakes==3.1.0
-python-dateutil==2.8.0
-pytz==2024.1
-raven==6.10.0
-rcssmin==1.1.1
-requests==2.31.0
-requests-oauthlib==1.2.0
-rjsmin==1.2.1
-s3transfer==0.4.2
-sentry-sdk==2.8.0
-six==1.16.0
-soupsieve==2.0.1
-sqlparse==0.5.0
-telepath==0.3.1
-Unidecode==1.1.1
-urllib3==1.26.18
-wagtail==6.0.1
-wagtailcodeblock==1.29.0.1
-waitress==2.1.2
-Wand==0.5.5
-webencodings==0.5.1
-whitenoise==5.3.0
-Willow==1.6.2
-XlsxWriter==1.2.8
-zope.event==5.0
-zope.interface==6.1
+anyascii==0.3.2 ; python_version >= "3.9" and python_version < "4.0"
+asgiref==3.7.2 ; python_version >= "3.9" and python_version < "4.0"
+autopep8==2.3.1 ; python_version >= "3.9" and python_version < "4.0"
+beautifulsoup4==4.8.2 ; python_version >= "3.9" and python_version < "4.0"
+black==24.3.0 ; python_version >= "3.9" and python_version < "4.0"
+boto3==1.17.112 ; python_version >= "3.9" and python_version < "4.0"
+botocore==1.20.112 ; python_version >= "3.9" and python_version < "4.0"
+certifi==2023.7.22 ; python_version >= "3.9" and python_version < "4.0"
+cffi==1.16.0 ; platform_python_implementation == "CPython" and sys_platform == "win32" and python_version >= "3.9" and python_version < "4.0"
+cfgv==3.4.0 ; python_version >= "3.9" and python_version < "4"
+chardet==3.0.4 ; python_version >= "3.9" and python_version < "4.0"
+charset-normalizer==3.3.2 ; python_version >= "3.9" and python_version < "4.0"
+click==8.1.7 ; python_version >= "3.9" and python_version < "4.0"
+colorama==0.4.6 ; python_version >= "3.9" and python_version < "4.0" and platform_system == "Windows"
+coverage==7.3.2 ; python_version >= "3.9" and python_version < "4.0"
+defusedxml==0.7.1 ; python_version >= "3.9" and python_version < "4.0"
+distlib==0.3.8 ; python_version >= "3.9" and python_version < "4"
+dj-database-url==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+django-appconf==1.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-compressor==4.4 ; python_version >= "3.9" and python_version < "4.0"
+django-environ==0.4.5 ; python_version >= "3.9" and python_version < "4.0"
+django-filter==23.3 ; python_version >= "3.9" and python_version < "4.0"
+django-ipware==3.0.7 ; python_version >= "3.9" and python_version < "4.0"
+django-log-formatter-asim==0.0.5 ; python_version >= "3.9" and python_version < "4"
+django-log-formatter-ecs==0.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-modelcluster==6.0 ; python_version >= "3.9" and python_version < "4.0"
+django-oauth-toolkit==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+django-permissionedforms==0.1 ; python_version >= "3.9" and python_version < "4.0"
+django-sass-processor==1.3 ; python_version >= "3.9" and python_version < "4.0"
+django-simple-history==3.4.0 ; python_version >= "3.9" and python_version < "4.0"
+django-staff-sso-client==3.1.1 ; python_version >= "3.9" and python_version < "4.0"
+django-storages==1.11.1 ; python_version >= "3.9" and python_version < "4.0"
+django-taggit==2.1.0 ; python_version >= "3.9" and python_version < "4.0"
+django-treebeard==4.7 ; python_version >= "3.9" and python_version < "4.0"
+django==3.2.25 ; python_version >= "3.9" and python_version < "4.0"
+djangorestframework==3.15.1 ; python_version >= "3.9" and python_version < "4.0"
+docutils==0.14 ; python_version >= "3.9" and python_version < "4.0"
+draftjs-exporter==2.1.6 ; python_version >= "3.9" and python_version < "4.0"
+et-xmlfile==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+filelock==3.15.4 ; python_version >= "3.9" and python_version < "4"
+filetype==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+flake8==7.1.1 ; python_version >= "3.9" and python_version < "4.0"
+freezegun==1.2.2 ; python_version >= "3.9" and python_version < "4.0"
+gevent==23.9.1 ; python_version >= "3.9" and python_version < "4.0"
+greenlet==3.0.1 ; platform_python_implementation == "CPython" and python_version < "4.0" and python_version >= "3.9"
+html5lib==1.0.1 ; python_version >= "3.9" and python_version < "4.0"
+identify==2.6.0 ; python_version >= "3.9" and python_version < "4"
+idna==3.7 ; python_version >= "3.9" and python_version < "4.0"
+jmespath==0.9.4 ; python_version >= "3.9" and python_version < "4.0"
+kubi-ecs-logger==0.1.2 ; python_version >= "3.9" and python_version < "4"
+l18n==2021.3 ; python_version >= "3.9" and python_version < "4.0"
+libsass==0.22.0 ; python_version >= "3.9" and python_version < "4.0"
+marshmallow==3.19.0 ; python_version >= "3.9" and python_version < "4"
+mccabe==0.7.0 ; python_version >= "3.9" and python_version < "4.0"
+mohawk==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+mypy-extensions==1.0.0 ; python_version >= "3.9" and python_version < "4.0"
+nodeenv==1.9.1 ; python_version >= "3.9" and python_version < "4"
+oauthlib==3.0.2 ; python_version >= "3.9" and python_version < "4.0"
+openpyxl==3.1.2 ; python_version >= "3.9" and python_version < "4.0"
+packaging==23.2 ; python_version >= "3.9" and python_version < "4.0"
+pathspec==0.11.2 ; python_version >= "3.9" and python_version < "4.0"
+pillow-heif==0.13.1 ; python_version >= "3.9" and python_version < "4.0"
+pillow==10.3.0 ; python_version >= "3.9" and python_version < "4.0"
+platformdirs==3.11.0 ; python_version >= "3.9" and python_version < "4.0"
+pre-commit==3.8.0 ; python_version >= "3.9" and python_version < "4"
+psycopg2==2.9.9 ; python_version >= "3.9" and python_version < "4.0"
+pycodestyle==2.12.1 ; python_version >= "3.9" and python_version < "4.0"
+pycparser==2.21 ; python_version >= "3.9" and platform_python_implementation == "CPython" and sys_platform == "win32" and python_version < "4.0"
+pyflakes==3.2.0 ; python_version >= "3.9" and python_version < "4.0"
+python-dateutil==2.8.0 ; python_version >= "3.9" and python_version < "4.0"
+pytz==2020.5 ; python_version >= "3.9" and python_version < "4.0"
+pyyaml==6.0.2 ; python_version >= "3.9" and python_version < "4"
+raven==6.10.0 ; python_version >= "3.9" and python_version < "4.0"
+rcssmin==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+requests-oauthlib==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+requests==2.32.0 ; python_version >= "3.9" and python_version < "4.0"
+rjsmin==1.2.1 ; python_version >= "3.9" and python_version < "4.0"
+s3transfer==0.4.2 ; python_version >= "3.9" and python_version < "4.0"
+sentry-sdk==1.14.0 ; python_version >= "3.9" and python_version < "4.0"
+setuptools==70.0.0 ; python_version >= "3.9" and python_version < "4.0"
+six==1.16.0 ; python_version >= "3.9" and python_version < "4.0"
+soupsieve==2.0.1 ; python_version >= "3.9" and python_version < "4.0"
+sqlparse==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+telepath==0.3.1 ; python_version >= "3.9" and python_version < "4.0"
+tomli==2.0.1 ; python_version >= "3.9" and python_version < "3.11"
+typing-extensions==4.8.0 ; python_version >= "3.9" and python_version < "3.11"
+unidecode==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+urllib3==1.26.18 ; python_version >= "3.9" and python_version < "4.0"
+virtualenv==20.26.3 ; python_version >= "3.9" and python_version < "4"
+wagtail==5.1.3 ; python_version >= "3.9" and python_version < "4.0"
+wagtailcodeblock==1.29.0.1 ; python_version >= "3.9" and python_version < "4.0"
+waitress==2.1.2 ; python_version >= "3.9" and python_version < "4.0"
+wand==0.5.5 ; python_version >= "3.9" and python_version < "4.0"
+webencodings==0.5.1 ; python_version >= "3.9" and python_version < "4.0"
+whitenoise==5.3.0 ; python_version >= "3.9" and python_version < "4"
+willow[heif]==1.6.2 ; python_version >= "3.9" and python_version < "4.0"
+xlsxwriter==1.2.8 ; python_version >= "3.9" and python_version < "4.0"
+zope-event==5.0 ; python_version >= "3.9" and python_version < "4.0"
+zope-interface==6.1 ; python_version >= "3.9" and python_version < "4.0"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,86 +1,97 @@
-anyascii==0.3.2
-asgiref==3.7.2
-autopep8==1.4.4
-beautifulsoup4==4.8.2
-black==24.3.0
-boto3==1.17.112
-botocore==1.20.112
-certifi==2024.7.4
-chardet==3.0.4
-charset-normalizer==3.3.2
-click==8.1.7
-coverage==7.3.2
-defusedxml==0.7.1
-dj-database-url==0.5.0
-Django==4.2.15
-django-appconf==1.0.6
-django-compressor==4.4
-django-environ==0.4.5
-django-filter==23.5
-django-ipware==3.0.7
-django-log-formatter-asim==0.0.5
-django-log-formatter-ecs==0.0.5
-django-modelcluster==6.3
-django-oauth-toolkit==1.2.0
-django-permissionedforms==0.1
-django-sass-processor==1.3
-django-simple-history==3.4.0
-django-staff-sso-client==4.2.1
-django-storages==1.11.1
-django-taggit==5.0.1
-django-treebeard==4.7
-djangorestframework==3.14.0
-docutils==0.14
-draftjs-exporter==2.1.6
-et-xmlfile==1.1.0
-filetype==1.2.0
-flake8==6.1.0
-freezegun==1.2.2
-gevent==23.9.1
-greenlet==3.0.1
-html5lib==1.0.1
-idna==3.7
-jmespath==0.9.4
-kubi-ecs-logger==0.1.2
-l18n==2021.3
-laces==0.1.1
-libsass==0.22.0
-marshmallow==3.19.0
-mccabe==0.7.0
-mohawk==1.1.0
-mypy-extensions==1.0.0
-oauthlib==3.0.2
-openpyxl==3.1.2
-packaging==23.2
-pathspec==0.11.2
-Pillow==10.3.0
-pillow-heif==0.13.1
-platformdirs==3.11.0
-psycopg2==2.9.9
-pycodestyle==2.11.1
-pyflakes==3.1.0
-python-dateutil==2.8.0
-pytz==2024.1
-raven==6.10.0
-rcssmin==1.1.1
-requests==2.31.0
-requests-oauthlib==1.2.0
-rjsmin==1.2.1
-s3transfer==0.4.2
-sentry-sdk==2.8.0
-six==1.16.0
-soupsieve==2.0.1
-sqlparse==0.5.0
-telepath==0.3.1
-Unidecode==1.1.1
-urllib3==1.26.18
-wagtail==6.0.1
-wagtailcodeblock==1.29.0.1
-waitress==2.1.2
-Wand==0.5.5
-webencodings==0.5.1
-whitenoise==5.3.0
-Willow==1.6.2
-XlsxWriter==1.2.8
-zope.event==5.0
-zope.interface==6.1
+anyascii==0.3.2 ; python_version >= "3.9" and python_version < "4.0"
+asgiref==3.7.2 ; python_version >= "3.9" and python_version < "4.0"
+autopep8==2.3.1 ; python_version >= "3.9" and python_version < "4.0"
+beautifulsoup4==4.8.2 ; python_version >= "3.9" and python_version < "4.0"
+boto3==1.17.112 ; python_version >= "3.9" and python_version < "4.0"
+botocore==1.20.112 ; python_version >= "3.9" and python_version < "4.0"
+certifi==2023.7.22 ; python_version >= "3.9" and python_version < "4.0"
+cffi==1.16.0 ; platform_python_implementation == "CPython" and sys_platform == "win32" and python_version >= "3.9" and python_version < "4.0"
+cfgv==3.4.0 ; python_version >= "3.9" and python_version < "4"
+chardet==3.0.4 ; python_version >= "3.9" and python_version < "4.0"
+charset-normalizer==3.3.2 ; python_version >= "3.9" and python_version < "4.0"
+defusedxml==0.7.1 ; python_version >= "3.9" and python_version < "4.0"
+distlib==0.3.8 ; python_version >= "3.9" and python_version < "4"
+dj-database-url==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+django-appconf==1.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-audit-log-middleware==0.0.4 ; python_version >= "3.9" and python_version < "4.0"
+django-compressor==4.4 ; python_version >= "3.9" and python_version < "4.0"
+django-environ==0.4.5 ; python_version >= "3.9" and python_version < "4.0"
+django-filter==23.3 ; python_version >= "3.9" and python_version < "4.0"
+django-ipware==3.0.7 ; python_version >= "3.9" and python_version < "4.0"
+django-log-formatter-asim==0.0.5 ; python_version >= "3.9" and python_version < "4"
+django-log-formatter-ecs==0.0.5 ; python_version >= "3.9" and python_version < "4.0"
+django-modelcluster==6.0 ; python_version >= "3.9" and python_version < "4.0"
+django-oauth-toolkit==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+django-permissionedforms==0.1 ; python_version >= "3.9" and python_version < "4.0"
+django-sass-processor==1.3 ; python_version >= "3.9" and python_version < "4.0"
+django-simple-history==3.4.0 ; python_version >= "3.9" and python_version < "4.0"
+django-staff-sso-client==3.1.1 ; python_version >= "3.9" and python_version < "4.0"
+django-storages==1.11.1 ; python_version >= "3.9" and python_version < "4.0"
+django-taggit==2.1.0 ; python_version >= "3.9" and python_version < "4.0"
+django-treebeard==4.7 ; python_version >= "3.9" and python_version < "4.0"
+django==3.2.25 ; python_version >= "3.9" and python_version < "4.0"
+djangorestframework==3.15.1 ; python_version >= "3.9" and python_version < "4.0"
+docutils==0.14 ; python_version >= "3.9" and python_version < "4.0"
+draftjs-exporter==2.1.6 ; python_version >= "3.9" and python_version < "4.0"
+ecs-logging==2.1.0 ; python_version >= "3.9" and python_version < "4"
+elastic-apm==6.19.0 ; python_version >= "3.9" and python_version < "4"
+et-xmlfile==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+filelock==3.15.4 ; python_version >= "3.9" and python_version < "4"
+filetype==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+flake8==7.1.1 ; python_version >= "3.9" and python_version < "4.0"
+gevent==23.9.1 ; python_version >= "3.9" and python_version < "4.0"
+greenlet==3.0.1 ; python_version >= "3.9" and python_version < "4.0"
+html5lib==1.0.1 ; python_version >= "3.9" and python_version < "4.0"
+identify==2.6.0 ; python_version >= "3.9" and python_version < "4"
+idna==3.7 ; python_version >= "3.9" and python_version < "4.0"
+jmespath==0.9.4 ; python_version >= "3.9" and python_version < "4.0"
+kubi-ecs-logger==0.1.2 ; python_version >= "3.9" and python_version < "4"
+l18n==2021.3 ; python_version >= "3.9" and python_version < "4.0"
+libsass==0.22.0 ; python_version >= "3.9" and python_version < "4.0"
+marshmallow==3.19.0 ; python_version >= "3.9" and python_version < "4"
+mccabe==0.7.0 ; python_version >= "3.9" and python_version < "4.0"
+mohawk==1.1.0 ; python_version >= "3.9" and python_version < "4.0"
+nodeenv==1.9.1 ; python_version >= "3.9" and python_version < "4"
+oauthlib==3.0.2 ; python_version >= "3.9" and python_version < "4.0"
+openpyxl==3.1.2 ; python_version >= "3.9" and python_version < "4.0"
+packaging==23.2 ; python_version >= "3.9" and python_version < "4"
+pillow-heif==0.13.1 ; python_version >= "3.9" and python_version < "4.0"
+pillow==10.3.0 ; python_version >= "3.9" and python_version < "4.0"
+platformdirs==3.11.0 ; python_version >= "3.9" and python_version < "4"
+pre-commit==3.8.0 ; python_version >= "3.9" and python_version < "4"
+psycogreen==1.0.2 ; python_version >= "3.9" and python_version < "4.0"
+psycopg2==2.9.9 ; python_version >= "3.9" and python_version < "4.0"
+pycodestyle==2.12.1 ; python_version >= "3.9" and python_version < "4.0"
+pycparser==2.21 ; python_version >= "3.9" and platform_python_implementation == "CPython" and sys_platform == "win32" and python_version < "4.0"
+pyflakes==3.2.0 ; python_version >= "3.9" and python_version < "4.0"
+python-dateutil==2.8.0 ; python_version >= "3.9" and python_version < "4.0"
+pytz==2020.5 ; python_version >= "3.9" and python_version < "4.0"
+pyyaml==6.0.2 ; python_version >= "3.9" and python_version < "4"
+raven==6.10.0 ; python_version >= "3.9" and python_version < "4.0"
+rcssmin==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+requests-oauthlib==1.2.0 ; python_version >= "3.9" and python_version < "4.0"
+requests==2.32.0 ; python_version >= "3.9" and python_version < "4.0"
+rjsmin==1.2.1 ; python_version >= "3.9" and python_version < "4.0"
+s3transfer==0.4.2 ; python_version >= "3.9" and python_version < "4.0"
+sentry-sdk==1.14.0 ; python_version >= "3.9" and python_version < "4.0"
+setuptools==70.0.0 ; python_version >= "3.9" and python_version < "4.0"
+six==1.16.0 ; python_version >= "3.9" and python_version < "4.0"
+soupsieve==2.0.1 ; python_version >= "3.9" and python_version < "4.0"
+sqlparse==0.5.0 ; python_version >= "3.9" and python_version < "4.0"
+telepath==0.3.1 ; python_version >= "3.9" and python_version < "4.0"
+tomli==2.0.1 ; python_version >= "3.9" and python_version < "3.11"
+typing-extensions==4.8.0 ; python_version >= "3.9" and python_version < "3.11"
+unidecode==1.1.1 ; python_version >= "3.9" and python_version < "4.0"
+urllib3==1.26.18 ; python_version >= "3.9" and python_version < "4.0"
+virtualenv==20.26.3 ; python_version >= "3.9" and python_version < "4"
+wagtail==5.1.3 ; python_version >= "3.9" and python_version < "4.0"
+wagtailcodeblock==1.29.0.1 ; python_version >= "3.9" and python_version < "4.0"
+waitress==2.1.2 ; python_version >= "3.9" and python_version < "4.0"
+wand==0.5.5 ; python_version >= "3.9" and python_version < "4.0"
+webencodings==0.5.1 ; python_version >= "3.9" and python_version < "4.0"
+whitenoise==5.3.0 ; python_version >= "3.9" and python_version < "4"
+willow[heif]==1.6.2 ; python_version >= "3.9" and python_version < "4.0"
+wrapt==1.14.1 ; python_version >= "3.9" and python_version < "4"
+xlsxwriter==1.2.8 ; python_version >= "3.9" and python_version < "4.0"
+zope-event==5.0 ; python_version >= "3.9" and python_version < "4.0"
+zope-interface==6.1 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
There are setuptools-related errors installing autopep8 in Jenkins, e.g.

> AttributeError: module 'setuptools.dist' has no attribute 'check_test_suite'

So bumping it to the latest version, and also other packages that are related to it.