### PR TITLE
Chore/Remove style dependencies and add elastic-apm

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 anyascii==0.3.2
 asgiref==3.7.2
-autopep8==1.4.4
 beautifulsoup4==4.8.2
 black==24.3.0
 boto3==1.17.112

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,7 @@ django-treebeard==4.7
 djangorestframework==3.14.0
 docutils==0.14
 draftjs-exporter==2.1.6
+elastic-apm==6.19.0
 et-xmlfile==1.1.0
 filetype==1.2.0
 flake8==6.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -32,6 +32,7 @@ django-treebeard==4.7
 djangorestframework==3.14.0
 docutils==0.14
 draftjs-exporter==2.1.6
+elastic-apm==6.19.0
 et-xmlfile==1.1.0
 filetype==1.2.0
 flake8==6.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,5 @@
 anyascii==0.3.2
 asgiref==3.7.2
-autopep8==1.4.4
 beautifulsoup4==4.8.2
 black==24.3.0
 boto3==1.17.112

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -31,6 +31,7 @@ django-treebeard==4.7
 djangorestframework==3.14.0
 docutils==0.14
 draftjs-exporter==2.1.6
+elastic-apm==6.19.0
 et-xmlfile==1.1.0
 filetype==1.2.0
 flake8==6.1.0


### PR DESCRIPTION
There are setuptools-related errors installing autopep8 in Jenkins, e.g.

> AttributeError: module 'setuptools.dist' has no attribute 'check_test_suite'

So manually removing them from base.txt and prod.txt.

And elastic-apm seemed to be missing, and Django won't start without it because it's in
INSTALLED_APPS, so added that in too.

NOTE: I suspect pyproject.toml and poetry.lock files have become out of sync with the requirements.txt files, e.g. Django is 3.2.25 in poetry.lock, but 4.2.15 in requirements/prod.txt.

It might be a small project to link everything back up. For now, have just made these changes manually in the requirements files, which is how I suspect other recent changes have been made.