### PR TITLE
feat/DT-2279-create-inline-feedback-api-for-data-flow

### DIFF
--- a/api_pipeline/factories.py
+++ b/api_pipeline/factories.py
@@ -1,0 +1,17 @@
+import string
+import factory
+from datetime import datetime
+from factory.fuzzy import FuzzyText
+
+
+class UserInlineFeedbackSurveyFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = "inline_feedback.UserInlineFeedbackSurvey"
+
+    created_date = datetime.now()
+    modified_date = datetime.now()
+    location = FuzzyText(length=4, chars=string.digits, suffix="%")
+    was_this_page_helpful = True
+    inline_feedback_choices = FuzzyText(length=6, chars=string.digits, suffix="%")
+    more_detail = FuzzyText(length=2, chars=string.digits, suffix="%")

--- a/api_pipeline/serializers.py
+++ b/api_pipeline/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from inline_feedback.models import UserInlineFeedbackSurvey
+
+
+class UserInlineFeedbackSurveySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UserInlineFeedbackSurvey
+        fields = "__all__"

--- a/api_pipeline/test.py
+++ b/api_pipeline/test.py
@@ -1,0 +1,130 @@
+import datetime
+import mohawk
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+
+from api_pipeline.factories import UserInlineFeedbackSurveyFactory
+
+
+User = get_user_model()
+
+test_url = "http://testserver" + reverse("user-inline-feedback-survey")
+
+
+def hawk_auth_sender(
+    key_id="access_key",
+    secret_key="secret_key",
+    url=test_url,
+    method="GET",
+    content_type="application/json",
+    timestamp=None,
+):
+    if timestamp is None:
+        timestamp = int(datetime.datetime.now().timestamp())
+
+    sender = mohawk.Sender(
+        {
+            "id": key_id,
+            "key": secret_key,
+            "algorithm": "sha256",
+        },
+        url,
+        method,
+        content="",
+        content_type=content_type,
+    )
+
+    sender.timestamp = timestamp
+    request_header = sender.request_header
+
+    return request_header
+
+
+class TestHawkTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.client.login(username="testuser", password="testpassword")
+
+    @override_settings(
+        HAWK_INCOMING_ACCESS_KEY="access_key",
+        HAWK_INCOMING_SECRET_KEY="secret_key",
+    )
+    def test_empty_object_returned_with_authentication(self):
+        """If the Authorization and X-Forwarded-For headers are correct, then
+        the correct, and authentic, data is returned
+        """
+        sender = hawk_auth_sender()
+        response = self.client.get(
+            test_url,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=sender,
+            HTTP_X_FORWARDED_FOR="1.2.3.4, 123.123.123.123",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    @override_settings(
+        HAWK_INCOMING_ACCESS_KEY="access_key",
+        HAWK_INCOMING_SECRET_KEY="secret_key",
+    )
+    def test_object_returned_with_authentication(self):
+        """If the Authorization and X-Forwarded-For headers are correct, then
+        the correct, and authentic, data is returned
+        """
+        feedback1 = UserInlineFeedbackSurveyFactory()
+        sender = hawk_auth_sender()
+        response = self.client.get(
+            test_url,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=sender,
+            HTTP_X_FORWARDED_FOR="1.2.3.4, 123.123.123.123",
+        )
+        year = datetime.date.today().year
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()[0]) == 7
+        assert response.json()[0]["id"] == feedback1.id
+        assert str(year) in response.json()[0]["created_date"]
+        assert str(year) in response.json()[0]["modified_date"]
+        assert response.json()[0]["location"] == feedback1.location
+        assert (
+            response.json()[0]["was_this_page_helpful"]
+            == feedback1.was_this_page_helpful
+        )
+        assert (
+            response.json()[0]["inline_feedback_choices"]
+            == feedback1.inline_feedback_choices
+        )
+        assert response.json()[0]["more_detail"] == feedback1.more_detail
+
+    @override_settings(
+        HAWK_INCOMING_ACCESS_KEY="wrong-id",
+        HAWK_INCOMING_SECRET_KEY="secret_key",
+    )
+    def test_bad_credentials_mean_401_returned(self):
+        """If the wrong credentials are used, then a 401 is returned."""
+        sender = hawk_auth_sender()
+        response = self.client.get(
+            test_url,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=sender,
+            HTTP_X_FORWARDED_FOR="1.2.3.4, 123.123.123.123",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @override_settings(
+        HAWK_INCOMING_ACCESS_KEY="access_key",
+        HAWK_INCOMING_SECRET_KEY="secret_key",
+    )
+    def test_missing_authorization_header(self):
+        """If the Authorization header is missing, then a 401 is returned."""
+        response = self.client.get(
+            test_url,
+            content_type="application/json",
+            HTTP_X_FORWARDED_FOR="1.2.3.4, 123.123.123.123",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/api_pipeline/urls.py
+++ b/api_pipeline/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from .views import UserInlineFeedbackSurveyViewSet
+
+urlpatterns = [
+    path(
+        "user-inline-feedback-survey",
+        UserInlineFeedbackSurveyViewSet.as_view({"get": "list"}),
+        name="user-inline-feedback-survey",
+    ),
+]

--- a/api_pipeline/views.py
+++ b/api_pipeline/views.py
@@ -1,0 +1,18 @@
+from rest_framework import viewsets
+from rest_framework.pagination import PageNumberPagination
+
+from .serializers import UserInlineFeedbackSurveySerializer
+from inline_feedback.models import UserInlineFeedbackSurvey
+
+from article.hawk import HawkAuthentication
+
+
+class UserInlineFeedbackSurveyViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint to list user satisfaction survey results for ingestion by data flow
+    """
+
+    authentication_classes = (HawkAuthentication,)
+    queryset = UserInlineFeedbackSurvey.objects.all()
+    serializer_class = UserInlineFeedbackSurveySerializer
+    pagination_class = PageNumberPagination

--- a/api_v1/inline_feedback/tests.py
+++ b/api_v1/inline_feedback/tests.py
@@ -33,13 +33,11 @@ class InlineFeedbackAPI(TestCase):
             reverse("inline_feedback:create"),
             {"location": "some location", "was_this_page_helpful": "true"},
         )
-        assert response.json() == {
-            "id": 1,
-            "location": "some location",
-            "was_this_page_helpful": True,
-            "inline_feedback_choices": "",
-            "more_detail": "",
-        }
+        assert len(response.json()) == 5
+        assert response.json()["location"] == "some location"
+        assert response.json()["was_this_page_helpful"] is True
+        assert response.json()["inline_feedback_choices"] == ""
+        assert response.json()["more_detail"] == ""
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_updating_inline_feedback(self):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "sass_processor",
     "rest_framework",
     "api_v1",
+    "api_pipeline",
 ]
 
 MIDDLEWARE = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from authbroker_client import urls as authbroker_client_urls
 
 from article import urls as article_urls
+from api_pipeline import urls as api_pipeline_urls
 from search import views as search_views
 from api_v1 import urls as apiv1_urls
 
@@ -21,6 +22,7 @@ urlpatterns = [
     path("pingdom/", include("pingdom.urls")),
     path("api/feeds/", include(article_urls)),
     path("api/v1/", include(apiv1_urls)),
+    path("api/pipeline/", include(api_pipeline_urls)),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:


### PR DESCRIPTION
The PR create a new endpoint around inline feedback so Data Flow can pull user satisfaction survey data.
https://uktrade.atlassian.net/browse/DT-2279?atlOrigin=eyJpIjoiZmVjNTc2YWY4OWQzNGNlYzk5YTgwZWI3ZTQ1Y2E5YWEiLCJwIjoiaiJ9