### PR TITLE
fix: update waitress cmd to include trusted-proxy-headers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate --noinput && python manage.py compilescss && python manage.py collectstatic --noinput && waitress-serve --port=$PORT config.wsgi:application
+web: python manage.py migrate --noinput && python manage.py compilescss && python manage.py collectstatic --noinput && waitress-serve --ident='' --trusted-proxy '*' --trusted-proxy-headers 'x-forwarded-proto' --port=$PORT config.wsgi:application


### PR DESCRIPTION
This change adds additional trusted headers when running the waitress server. Without this the inline feedback pipeline we have running from Data Flow will fail to authenticate.