### PR TITLE
fix: conditionally set s3 bucket paths for both envs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -174,6 +174,9 @@ AWS_DEFAULT_ACL = None
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
+if not is_copilot():
+    AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
+
 
 if not is_copilot():
     # Only required in Cloud Foundry.


### PR DESCRIPTION
Whilst we are migrating to the DBT Paas we need to make sure that S3 bucket path is backwards compatible to GOV Paas. This change checks to see what environment its on and then sets the bucket path accordingly. 