### PR TITLE
refactor/DT-2522: use sentry sdk instead of raven

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -198,7 +198,7 @@ if SENTRY_DSN:
         "environment": SENTRY_ENVIRONMENT,
         "enable_tracing": True,
         "integrations": [DjangoIntegration()],
-        "traces_sample_rate": SENTRY_SAMPLE_RATE,
+        "traces_sample_rate": float(SENTRY_SAMPLE_RATE),
     }
     if "shell" in sys.argv or "shell_plus" in sys.argv:
         sentry_kwargs["before_send"] = lambda event, hint: None

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -190,7 +190,7 @@ SENTRY_ENVIRONMENT = settings_env.sentry_environment
 
 try:
     SENTRY_SAMPLE_RATE = float(settings_env.sentry_sample_rate)
-except ValueError:
+except (ValueError, TypeError):
     SENTRY_SAMPLE_RATE = 0.2
 
 if SENTRY_DSN:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -186,8 +186,12 @@ if not is_copilot():
 FEEDBACK_URL = settings_env.feedback_url
 
 SENTRY_DSN = settings_env.sentry_dsn
-SENTRY_SAMPLE_RATE = settings_env.sentry_sample_rate
 SENTRY_ENVIRONMENT = settings_env.sentry_environment
+
+try:
+    SENTRY_SAMPLE_RATE = float(settings_env.sentry_sample_rate)
+except ValueError:
+    SENTRY_SAMPLE_RATE = 0.2
 
 if SENTRY_DSN:
     import sentry_sdk
@@ -198,7 +202,7 @@ if SENTRY_DSN:
         "environment": SENTRY_ENVIRONMENT,
         "enable_tracing": True,
         "integrations": [DjangoIntegration()],
-        "traces_sample_rate": float(SENTRY_SAMPLE_RATE),
+        "traces_sample_rate": SENTRY_SAMPLE_RATE,
     }
     if "shell" in sys.argv or "shell_plus" in sys.argv:
         sentry_kwargs["before_send"] = lambda event, hint: None

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -196,6 +196,7 @@ if SENTRY_DSN:
     sentry_kwargs = {
         "dsn": SENTRY_DSN,
         "environment": SENTRY_ENVIRONMENT,
+        "enable_tracing": True,
         "integrations": [DjangoIntegration()],
         "traces_sample_rate": SENTRY_SAMPLE_RATE,
     }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -192,12 +192,11 @@ SENTRY_ENVIRONMENT = settings_env.sentry_environment
 if SENTRY_DSN:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
-    from sentry_sdk.integrations.redis import RedisIntegration
 
     sentry_kwargs = {
         "dsn": SENTRY_DSN,
         "environment": SENTRY_ENVIRONMENT,
-        "integrations": [DjangoIntegration(), RedisIntegration()],
+        "integrations": [DjangoIntegration()],
         "traces_sample_rate": SENTRY_SAMPLE_RATE,
     }
     if "shell" in sys.argv or "shell_plus" in sys.argv:

--- a/config/urls.py
+++ b/config/urls.py
@@ -12,7 +12,9 @@ from article import urls as article_urls
 from api_pipeline import urls as api_pipeline_urls
 from search import views as search_views
 from api_v1 import urls as apiv1_urls
-from django.views.defaults import server_error
+
+def divide_by_zero_view(request):
+    a = 1/0
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),
@@ -24,7 +26,7 @@ urlpatterns = [
     path("api/feeds/", include(article_urls)),
     path("api/v1/", include(apiv1_urls)),
     path("api/pipeline/", include(api_pipeline_urls)),
-    path("fail/", server_error),
+    path("fail/", divide_by_zero_view),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,8 +13,6 @@ from api_pipeline import urls as api_pipeline_urls
 from search import views as search_views
 from api_v1 import urls as apiv1_urls
 
-def divide_by_zero_view(request):
-    a = 1/0
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),
@@ -26,7 +24,6 @@ urlpatterns = [
     path("api/feeds/", include(article_urls)),
     path("api/v1/", include(apiv1_urls)),
     path("api/pipeline/", include(api_pipeline_urls)),
-    path("fail/", divide_by_zero_view),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:

--- a/config/urls.py
+++ b/config/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path("api/feeds/", include(article_urls)),
     path("api/v1/", include(apiv1_urls)),
     path("api/pipeline/", include(api_pipeline_urls)),
-    path("fail/", server_error)
+    path("fail/", server_error),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:

--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,7 @@ from article import urls as article_urls
 from api_pipeline import urls as api_pipeline_urls
 from search import views as search_views
 from api_v1 import urls as apiv1_urls
+from django.views.defaults import server_error
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),
@@ -23,6 +24,7 @@ urlpatterns = [
     path("api/feeds/", include(article_urls)),
     path("api/v1/", include(apiv1_urls)),
     path("api/pipeline/", include(api_pipeline_urls)),
+    path("fail/", server_error)
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -64,7 +64,6 @@ pydantic-settings
 pyflakes
 python-dateutil
 pytz
-raven
 rcssmin
 requests
 requests-oauthlib

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -354,8 +354,6 @@ pytz==2024.1
     #   l18n
 pyyaml==6.0.2
     # via pre-commit
-raven==6.10.0
-    # via -r requirements/base.in
 rcssmin==1.1.1
     # via
     #   -r requirements/base.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -65,7 +65,6 @@ pydantic-settings
 pyflakes
 python-dateutil
 pytz
-raven
 rcssmin
 requests
 requests-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -366,8 +366,6 @@ pytz==2024.1
     #   l18n
 pyyaml==6.0.2
     # via pre-commit
-raven==6.10.0
-    # via -r requirements/dev.in
 rcssmin==1.1.1
     # via
     #   -r requirements/dev.in

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -57,7 +57,6 @@ pycodestyle
 pydantic-settings
 python-dateutil
 pytz
-raven
 rcssmin
 requests
 requests-oauthlib

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -337,8 +337,6 @@ pytz==2022.4
     #   l18n
 pyyaml==6.0.2
     # via pre-commit
-raven==6.10.0
-    # via -r requirements/prod.in
 rcssmin==1.1.1
     # via
     #   -r requirements/prod.in


### PR DESCRIPTION
Ticket [DT-2522](https://uktrade.atlassian.net/jira/software/projects/DT/boards/356?isInsightsOpen=true&selectedIssue=DT-2522)

This change removes Raven and uses the Sentry SDK instead as currently we are not catching performance metrics and Raven is deprecated. Another benefit is that using the SDK is consistent with other apps in the dept.

[DT-2522]: https://uktrade.atlassian.net/browse/DT-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ